### PR TITLE
[BUGFIX] Fix compatibility with php8 curl init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# CachePurger for Varnish 
+# CachePurger for Varnish
 
 - supports clear per page or all pages
-- supports TYPO3 9.5-10.4
-- requires php >= 7.4
+- supports TYPO3 >= 11.5
+- requires php >= 8.1
 
 # Example configuration in Typoscript
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": ["GPL-2.0+"],
   "keywords": ["TYPO3 CMS", "Purge"],
   "require": {
-    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5"
+    "typo3/cms-core": "^11.5"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,12 +4,12 @@ $EM_CONF[$_EXTKEY] = [
     'title' => 'Cache Purger',
     'description' => 'Purge cached URLs within Varnish instances',
     'category' => 'misc',
-    'version' => '1.0.5',
+    'version' => '2.0.0',
     'state' => 'stable',
     'clearCacheOnLoad' => 0,
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-11.5.99',
+            'typo3' => '11.5.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
php >= 8 change return types of curl_multi_init and curl_init methods

also bump version to 2.0 with support only php8 and typo3 > 11.5 